### PR TITLE
fix bug where subword-capitalize was being incorrectly aliased

### DIFF
--- a/src/main/lisp/malabar-codegen.el
+++ b/src/main/lisp/malabar-codegen.el
@@ -19,10 +19,11 @@
 ;;
 (require 'cl)
 (require 'cc-cmds)
-(if (and (<= emacs-major-version 23)
-          (< emacs-minor-version 2))
-    (require 'cc-subword)
-  (require 'subword)
+(if (or (> emacs-major-version 23)
+        (and (= emacs-major-version 23)
+             (>= emacs-minor-version 2)))
+    (require 'subword)
+  (require 'cc-subword)
   (fset 'subword-capitalize 'c-capitalize-subword))
 
 (if malabar-use-external-cedet


### PR DESCRIPTION
In Emacs versions older than 23.2, the function subword-capitalize was
called c-capitalize-subword and was part of the cc-subword feature. In
those versions we want to require that feature and have
subword-capitalize be an alias for c-capitalize-subword.
