### PR TITLE
Fixed typo regarding the import-all command

### DIFF
--- a/src/main/lisp/malabar-mode.el
+++ b/src/main/lisp/malabar-mode.el
@@ -85,7 +85,7 @@
     ("Source"
      ["Insert getter/setter" malabar-insert-getset]
      ["Import class" malabar-import-one-class]
-     ["Import all classes" malaber-import-all]
+     ["Import all classes" malabar-import-all]
      ["Override method" malabar-override-method]
      ["Extend class" malabar-extend-class]
      ["Implement interface" malabar-implement-interface])


### PR DESCRIPTION
The menu item for `Import all classes` is incorrectly bound to `malaber-import-all` - note the typo.
