### PR TITLE
Fix paths

### DIFF
--- a/src/main/groovy/org/grumblesmurf/malabar/Project.groovy
+++ b/src/main/groovy/org/grumblesmurf/malabar/Project.groovy
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2009, 2010 Espen Wiborg <espenhw@grumblesmurf.org>
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,11 +15,12 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
  * 02110-1301 USA.
- */ 
+ */
 package org.grumblesmurf.malabar
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.resolver.filter.CumulativeScopeArtifactFilter;
+import java.util.regex.Matcher;
 
 class Project
 {
@@ -61,7 +62,7 @@ class Project
     def compiler;
 
     def mvnServer;
-    
+
     def runtest(testname) {
         return run(["test"], [], [ test: testname ]);
     }
@@ -144,22 +145,22 @@ class Project
 
         activeProfiles = mavenProject.activeProfiles.collect { it.id }
         availableProfiles = mavenProject.model.profiles.collect { it.id }
-        
-        srcDirectories = mavenProject.compileSourceRoots
-        classesDirectory = mavenProject.build.outputDirectory
+
+        srcDirectories = mavenProject.compileSourceRoots.collect { Utils.standardizeSlashes(it) }
+        classesDirectory = Utils.standardizeSlashes(mavenProject.build.outputDirectory)
         resources = mavenProject.resources.collect {
             // TODO: better resource handling
-            it.directory
+            Utils.standardizeSlashes(it.directory)
         }
 
-        testSrcDirectories = mavenProject.testCompileSourceRoots
+        testSrcDirectories = mavenProject.testCompileSourceRoots.collect { Utils.standardizeSlashes(it) }
         testSrcDirectories += testSrcDirectories.collect {
-            it.replaceFirst('src/test/java', 'src/test/groovy')
+            Utils.standardizeSlashes(it).replaceFirst('src/test/java', 'src/test/groovy')
         }
-        testClassesDirectory = mavenProject.build.testOutputDirectory
+        testClassesDirectory = Utils.standardizeSlashes(mavenProject.build.testOutputDirectory)
         testResources = mavenProject.testResources.collect {
             // TODO: better resource handling
-            it.directory
+            Utils.standardizeSlashes(it.directory)
         }
 
         def filter = new CumulativeScopeArtifactFilter([Artifact.SCOPE_COMPILE])

--- a/src/main/groovy/org/grumblesmurf/malabar/Utils.groovy
+++ b/src/main/groovy/org/grumblesmurf/malabar/Utils.groovy
@@ -83,4 +83,8 @@ class Utils
         result << "))";
         return result as String;
     }
+
+    static standardizeSlashes(String path) {
+        path.replaceAll('\\\\', '/')
+    }
 }

--- a/src/main/lisp/malabar-groovy.el
+++ b/src/main/lisp/malabar-groovy.el
@@ -157,7 +157,7 @@ variable once the eval server has started."
 (defun malabar-groovy-stop ()
   "Stop the inferior Groovy."
   (interactive)
-  (let ((start-time (float-time)) (groovy-process (get-buffer-process malabar-groovy-buffer-name)))  
+  (let ((start-time (float-time)) (groovy-process (get-buffer-process malabar-groovy-buffer-name)))
     (malabar-groovy-eval-in-process groovy-process "exit")
     (while (malabar-groovy-live-p)
       (sit-for 0.1)
@@ -202,10 +202,10 @@ pop to the Groovy console buffer."
         (progress-reporter-force-update reporter 4 "Starting Groovy...connecting to servers ")
         (make-comint malabar-groovy-compile-server-comint-name
                      (cons "localhost"
-                           (number-to-string malabar-groovy-compile-server-port)))
+                           malabar-groovy-compile-server-port))
         (make-comint malabar-groovy-eval-server-comint-name
                      (cons "localhost"
-                           (number-to-string malabar-groovy-eval-server-port)))
+                           malabar-groovy-eval-server-port))
         (progress-reporter-force-update reporter 5 "Starting Groovy...waiting for server prompts ")
         (malabar-groovy--wait-for-prompt malabar-groovy-compile-server-buffer-name
                                          initial-points-alist)

--- a/src/main/lisp/malabar-mode.el
+++ b/src/main/lisp/malabar-mode.el
@@ -85,7 +85,7 @@
     ("Source"
      ["Insert getter/setter" malabar-insert-getset]
      ["Import class" malabar-import-one-class]
-     ["Import all classes" malaber-import-all]
+     ["Import all classes" malabar-import-all]
      ["Override method" malabar-override-method]
      ["Extend class" malabar-extend-class]
      ["Implement interface" malabar-implement-interface])


### PR DESCRIPTION
Use a new utility function to standardize all separators to be a forward slash.  Forward slashes work on all OSs.  This fixes several problems found when using malabar-mode in Windows.

This also includes some fixes from the following issue comment:
https://github.com/espenhw/malabar-mode/issues/72#issuecomment-2848686
